### PR TITLE
Implemented logic to randomly fetch jokes from another source

### DIFF
--- a/src/components/JokeContainer.ts
+++ b/src/components/JokeContainer.ts
@@ -1,12 +1,18 @@
 import type { Joke, JokeStorage } from "../models/interfaces";
-import { getJoke, formatStorageJoke, storeJoke } from "../services/JokeService";
+import {
+    getJoke,
+    formatStorageJoke,
+    storeJoke,
+    getRandomJokeSource,
+} from "../services/JokeService";
 
 export const setJoke = async () => {
     const jokeContainer = document.querySelector("#jokes") as HTMLDivElement;
     const jokeP = document.createElement("p");
     jokeContainer.innerHTML = ``;
 
-    let newJoke: Joke = await getJoke("dadjoke");
+    let randomSource = getRandomJokeSource();
+    let newJoke: Joke = await getJoke(randomSource);
     let storage: JokeStorage = formatStorageJoke(newJoke);
     storeJoke(storage);
     if (newJoke) {

--- a/src/models/interfaces.ts
+++ b/src/models/interfaces.ts
@@ -4,7 +4,7 @@ export interface Joke {
     source: string;
 }
 
-export type JokeSource = "dadjoke";
+export type JokeSource = "dadjoke" | "chucknorris";
 
 export interface JokeData {
     joke: string;

--- a/src/services/JokeService.ts
+++ b/src/services/JokeService.ts
@@ -15,6 +15,9 @@ export const getJoke = async (source: JokeSource): Promise<Joke> => {
             case "dadjoke":
                 url = "https://icanhazdadjoke.com/";
                 break;
+            case "chucknorris":
+                url = "https://api.chucknorris.io/jokes/random";
+                break;
             default:
                 throw new Error(`Provided source: '${source}' is unsupported`);
         }
@@ -41,6 +44,12 @@ export const formatJokeData = (data: any, source: JokeSource): Joke => {
                 joke: data.joke,
                 source: "dadjoke",
             };
+        case "chucknorris":
+            return {
+                id: data.id,
+                joke: data.value,
+                source: "chucknorris",
+            };
         default:
             throw new Error(`Unsupported source: ${source}`);
     }
@@ -63,4 +72,10 @@ export const formatStorageJoke = (element: Joke): JokeStorage => {
 
 export const storeJoke = (entry: JokeStorage): void => {
     jokes.push(entry);
+};
+
+export const getRandomJokeSource = (): JokeSource => {
+    const sources: JokeSource[] = ["dadjoke", "chucknorris"];
+    const randomIndex = Math.floor(Math.random() * sources.length);
+    return sources[randomIndex];
 };


### PR DESCRIPTION
This pull request enhances the joke application by introducing support for multiple joke sources, specifically adding "Chuck Norris" jokes alongside the existing "Dad jokes." The changes include updates to the interfaces, joke-fetching logic, and storage formatting to accommodate the new joke source.

### Support for multiple joke sources:

* [`src/models/interfaces.ts`](diffhunk://#diff-3ee8ce28048977fe8dd93c351a9eacc9ec8c67a95b1d4e0294aa43a2ef05137eL7-R7): Extended the `JokeSource` type to include "chucknorris" as a valid joke source.
* [`src/services/JokeService.ts`](diffhunk://#diff-dcde69cf7ed06c2b9622165d6869ccc3ba7251a0607e831abf3c30a976bac4c4R18-R20): Updated the `getJoke` function to handle the new "chucknorris" source by adding its API endpoint, and modified the `formatJokeData` function to format jokes from the "Chuck Norris" API appropriately. [[1]](diffhunk://#diff-dcde69cf7ed06c2b9622165d6869ccc3ba7251a0607e831abf3c30a976bac4c4R18-R20) [[2]](diffhunk://#diff-dcde69cf7ed06c2b9622165d6869ccc3ba7251a0607e831abf3c30a976bac4c4R47-R52)

### Random joke source selection:

* [`src/services/JokeService.ts`](diffhunk://#diff-dcde69cf7ed06c2b9622165d6869ccc3ba7251a0607e831abf3c30a976bac4c4R76-R81): Added a new `getRandomJokeSource` function to randomly select a joke source from the available options ("dadjoke" and "chucknorris").
* [`src/components/JokeContainer.ts`](diffhunk://#diff-b8d582641c578b77408474ea1c7b4e5c6686db98879212c988e46b221f8de2cbL2-R15): Updated the `setJoke` function to use the `getRandomJokeSource` function for fetching jokes from a random source.